### PR TITLE
fix(grid-layout-search): fixed the layout.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@ node_modules
 
 server/config.js
 server/node_modules
+server/package-lock.json
 server/npm-*
 
 client/node_modules
+client/package-lock.json
 client/npm-*

--- a/client/src/components/views/Popular.jsx
+++ b/client/src/components/views/Popular.jsx
@@ -27,8 +27,9 @@ export default class Popular extends Component {
 	}
 
 	render = () => (
-		<div className='view-wrapper'>
-			<div className='shows-container'>
+		<div className='view-wrapper app-page-wrapper'>
+			<SearchBar/>
+			<div className='shows-container app-page-content has-search-bar'>
 				{
 					this.state.data.results &&
 						this.state.data.results.map(s =>

--- a/client/src/components/views/TopRated.jsx
+++ b/client/src/components/views/TopRated.jsx
@@ -27,8 +27,9 @@ export default class TopRated extends Component {
 	}
 
 	render = () => (
-		<div className='view-wrapper'>
-			<div className='shows-container'>
+		<div className='view-wrapper app-page-wrapper'>
+			<SearchBar/>
+			<div className='shows-container app-page-content has-search-bar'>
 				{
 					this.state.data.results &&
 						this.state.data.results.map(s =>

--- a/client/src/styles/Popular.scss
+++ b/client/src/styles/Popular.scss
@@ -1,5 +1,5 @@
 @import '_variables';
-
+@import '_elements';
 .shows-container {
   height: 100%;
   display: flex;

--- a/client/src/styles/SearchBar.scss
+++ b/client/src/styles/SearchBar.scss
@@ -1,0 +1,4 @@
+@import '_variables';
+
+.search-bar {}
+

--- a/client/src/styles/_elements.scss
+++ b/client/src/styles/_elements.scss
@@ -1,0 +1,9 @@
+@import '_variables';
+
+.app-page-wrapper{
+    .app-page-content{
+        &.has-search-bar{
+            margin-top: 45px;
+        }
+    }
+}


### PR DESCRIPTION
Implemented a generic and re-usable logic to have this consistent throughout the pages.

Just add the classes on the page, with the `has-search-bar` class on the `app-page-content` element.

<img width="1197" alt="screen shot 2017-10-08 at 6 27 46 pm" src="https://user-images.githubusercontent.com/9844254/31317210-698d4226-ac56-11e7-853b-73eb835dfcbd.png">

Fixes #2 